### PR TITLE
feat(post): 게시글 기능 추가 및 기본 CRUD 구현

### DIFF
--- a/src/main/java/com/hongjunland/boardtemplate/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/hongjunland/boardtemplate/common/exception/GlobalExceptionHandler.java
@@ -1,14 +1,16 @@
 package com.hongjunland.boardtemplate.common.exception;
 
 import com.hongjunland.boardtemplate.common.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Hidden;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.validation.ConstraintViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-
+@Hidden // swagger에 해당되지 않음
 @RestControllerAdvice
 public class GlobalExceptionHandler {
     @ExceptionHandler(EntityNotFoundException.class)

--- a/src/main/java/com/hongjunland/boardtemplate/post/application/PostService.java
+++ b/src/main/java/com/hongjunland/boardtemplate/post/application/PostService.java
@@ -1,0 +1,111 @@
+package com.hongjunland.boardtemplate.post.application;
+
+import com.hongjunland.boardtemplate.board.domain.BoardJpaEntity;
+import com.hongjunland.boardtemplate.board.infrastructure.BoardJpaRepository;
+import com.hongjunland.boardtemplate.post.domain.PostJpaEntity;
+import com.hongjunland.boardtemplate.post.dto.PostRequest;
+import com.hongjunland.boardtemplate.post.dto.PostResponse;
+import com.hongjunland.boardtemplate.post.infrastructure.PostJpaRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PostService {
+    private final PostJpaRepository postJpaRepository;
+    private final BoardJpaRepository boardJpaRepository;
+
+    @Transactional
+    public PostResponse createPost(Long boardId, PostRequest request) {
+        BoardJpaEntity board = boardJpaRepository.findById(boardId)
+                .orElseThrow(() -> new EntityNotFoundException("해당 게시판이 존재하지 않습니다."));
+
+        PostJpaEntity post = postJpaRepository.save(new PostJpaEntity(
+                board,
+                request.title(),
+                request.content(),
+                request.author()
+        ));
+        return PostResponse.builder()
+                .id(post.getId())
+                .boardId(post.getBoard().getId())
+                .boardName(post.getBoard().getName())
+                .author(post.getAuthor())
+                .title(post.getTitle())
+                .content(post.getContent())
+                .createdAt(post.getCreatedAt())
+                .updatedAt(post.getUpdatedAt())
+                .build();
+    }
+
+    @Transactional(readOnly = true)
+    public List<PostResponse> getPostsByBoardId(Long boardId) {
+        boardJpaRepository.findById(boardId).orElseThrow(
+                () -> new EntityNotFoundException("해당 게시판이 존재하지 않습니다")
+        );
+        return postJpaRepository.findByBoardId(boardId)
+                .stream()
+                .map((entity) ->
+                        PostResponse.builder()
+                                .id(entity.getId())
+                                .boardId(entity.getBoard().getId())
+                                .boardName(entity.getBoard().getName())
+                                .author(entity.getAuthor())
+                                .title(entity.getTitle())
+                                .content(entity.getContent())
+                                .createdAt(entity.getCreatedAt())
+                                .updatedAt(entity.getUpdatedAt())
+                                .build()
+                )
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public PostResponse getPostById(Long postId) {
+        PostJpaEntity post = postJpaRepository.findById(postId)
+                .orElseThrow(() -> new EntityNotFoundException("게시글을 찾을 수 없습니다."));
+        return PostResponse.builder()
+                .id(post.getId())
+                .boardId(post.getBoard().getId())
+                .boardName(post.getBoard().getName())
+                .author(post.getAuthor())
+                .title(post.getTitle())
+                .content(post.getContent())
+                .createdAt(post.getCreatedAt())
+                .updatedAt(post.getUpdatedAt())
+                .build();
+    }
+
+    @Transactional
+    public PostResponse updatePost(Long postId, PostRequest request) {
+        PostJpaEntity post = postJpaRepository.findById(postId)
+                .orElseThrow(() -> new EntityNotFoundException("게시글을 찾을 수 없습니다."));
+
+        post.update(request.title(), request.content());
+
+        return PostResponse.builder()
+                .id(post.getId())
+                .boardId(post.getBoard().getId())
+                .boardName(post.getBoard().getName())
+                .author(post.getAuthor())
+                .title(post.getTitle())
+                .content(post.getContent())
+                .createdAt(post.getCreatedAt())
+                .updatedAt(post.getUpdatedAt())
+                .build();
+    }
+
+    @Transactional
+    public void deletePost(Long postId) {
+        if (!postJpaRepository.existsById(postId)) {
+            throw new EntityNotFoundException("해당 게시글이 존재하지 않습니다.");
+        }
+        postJpaRepository.deleteById(postId);
+    }
+
+
+}

--- a/src/main/java/com/hongjunland/boardtemplate/post/domain/PostJpaEntity.java
+++ b/src/main/java/com/hongjunland/boardtemplate/post/domain/PostJpaEntity.java
@@ -1,0 +1,44 @@
+package com.hongjunland.boardtemplate.post.domain;
+
+import com.hongjunland.boardtemplate.board.domain.BoardJpaEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Table(name = "posts")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "board_id", nullable = false)
+    private BoardJpaEntity board;
+
+    private String title;
+    private String content;
+    private String author;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public PostJpaEntity(BoardJpaEntity board, String title, String content, String author) {
+        this.board = board;
+        this.title = title;
+        this.content = content;
+        this.author = author;
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void update(String title, String content) {
+        this.title = title;
+        this.content = content;
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/hongjunland/boardtemplate/post/dto/PostRequest.java
+++ b/src/main/java/com/hongjunland/boardtemplate/post/dto/PostRequest.java
@@ -1,0 +1,10 @@
+package com.hongjunland.boardtemplate.post.dto;
+
+import lombok.Builder;
+
+@Builder
+public record PostRequest(Long boardId,
+                          String title,
+                          String content,
+                          String author) {
+}

--- a/src/main/java/com/hongjunland/boardtemplate/post/dto/PostResponse.java
+++ b/src/main/java/com/hongjunland/boardtemplate/post/dto/PostResponse.java
@@ -1,0 +1,20 @@
+package com.hongjunland.boardtemplate.post.dto;
+
+import com.hongjunland.boardtemplate.post.domain.PostJpaEntity;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+@Builder
+public record PostResponse(
+        Long id,
+        Long boardId,
+        String boardName,
+        String title,
+        String content,
+        String author,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+
+}

--- a/src/main/java/com/hongjunland/boardtemplate/post/infrastructure/PostJpaRepository.java
+++ b/src/main/java/com/hongjunland/boardtemplate/post/infrastructure/PostJpaRepository.java
@@ -1,0 +1,12 @@
+package com.hongjunland.boardtemplate.post.infrastructure;
+
+import com.hongjunland.boardtemplate.post.domain.PostJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface PostJpaRepository extends JpaRepository<PostJpaEntity, Long> {
+    @Query("SELECT p FROM PostJpaEntity p JOIN FETCH p.board b WHERE b.id = :boardId")
+    List<PostJpaEntity> findByBoardId(Long boardId);
+}

--- a/src/main/java/com/hongjunland/boardtemplate/post/presentation/PostController.java
+++ b/src/main/java/com/hongjunland/boardtemplate/post/presentation/PostController.java
@@ -1,0 +1,53 @@
+package com.hongjunland.boardtemplate.post.presentation;
+
+import com.hongjunland.boardtemplate.common.response.BaseResponse;
+import com.hongjunland.boardtemplate.post.application.PostService;
+import com.hongjunland.boardtemplate.post.dto.PostRequest;
+import com.hongjunland.boardtemplate.post.dto.PostResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/boards/{boardId}/posts")
+public class PostController {
+    private final PostService postService;
+
+    @PostMapping
+    public BaseResponse<?> createPost(
+            @PathVariable Long boardId,
+            @RequestBody @Valid PostRequest request) {
+        PostResponse response = postService.createPost(boardId, request);
+        return BaseResponse.success(response);
+    }
+
+    @GetMapping
+    public BaseResponse<?> getAllPosts(@PathVariable Long boardId) {
+        return BaseResponse.success(postService.getPostsByBoardId(boardId));
+    }
+
+    @GetMapping("/{postId}")
+    public BaseResponse<?> getPostById(@PathVariable Long boardId, @PathVariable Long postId) {
+        return BaseResponse.success(postService.getPostById(postId));
+    }
+
+    @PutMapping("/{postId}")
+    public BaseResponse<?> updatePost(
+            @PathVariable Long boardId,
+            @PathVariable Long postId,
+            @RequestBody @Valid PostRequest request) {
+        PostResponse response = postService.updatePost(postId, request);
+        return BaseResponse.success(response);
+    }
+
+    @DeleteMapping("/{postId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public BaseResponse<?> deletePost(
+            @PathVariable Long boardId,
+            @PathVariable Long postId) {
+        postService.deletePost(postId);
+        return BaseResponse.success(null);
+    }
+}

--- a/src/test/java/com/hongjunland/boardtemplate/board/presentation/BoardControllerTest.java
+++ b/src/test/java/com/hongjunland/boardtemplate/board/presentation/BoardControllerTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;

--- a/src/test/java/com/hongjunland/boardtemplate/post/application/PostServiceTest.java
+++ b/src/test/java/com/hongjunland/boardtemplate/post/application/PostServiceTest.java
@@ -1,0 +1,180 @@
+package com.hongjunland.boardtemplate.post.application;
+
+import com.hongjunland.boardtemplate.board.domain.BoardJpaEntity;
+import com.hongjunland.boardtemplate.board.infrastructure.BoardJpaRepository;
+import com.hongjunland.boardtemplate.post.domain.PostJpaEntity;
+import com.hongjunland.boardtemplate.post.dto.PostRequest;
+import com.hongjunland.boardtemplate.post.dto.PostResponse;
+import com.hongjunland.boardtemplate.post.infrastructure.PostJpaRepository;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class PostServiceTest {
+
+    @Mock
+    private PostJpaRepository postJpaRepository;
+
+    @Mock
+    private BoardJpaRepository boardJpaRepository;
+
+    @InjectMocks
+    private PostService postService;
+
+    private BoardJpaEntity board;
+    private PostJpaEntity post;
+
+    @BeforeEach
+    void setup() {
+        board = BoardJpaEntity.builder()
+                .id(1L)
+                .name("공지사항")
+                .description("공지사항 게시판")
+                .build();
+
+        post = new PostJpaEntity(
+                board,
+                "첫 번째 게시글",
+                "내용입니다.",
+                "홍길동"
+        );
+    }
+
+    @Test
+    void 게시글_생성_테스트() {
+        // given
+        PostRequest request = PostRequest.builder()
+                .boardId(1L)
+                .title("첫 번째 게시글")
+                .content("내용입니다.")
+                .author("홍길동")
+                .build();
+
+        when(boardJpaRepository.findById(request.boardId())).thenReturn(Optional.of(board));
+        when(postJpaRepository.save(any(PostJpaEntity.class))).thenReturn(post);
+
+        // when
+        PostResponse response = postService.createPost(1L, request);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.title()).isEqualTo(request.title());
+        assertThat(response.content()).isEqualTo(request.content());
+        assertThat(response.author()).isEqualTo(request.author());
+
+        verify(postJpaRepository, times(1)).save(any(PostJpaEntity.class));
+    }
+
+    @Test
+    void 존재하지_않는_게시판에_게시글_작성_테스트() {
+        // given
+        PostRequest request = new PostRequest(999L, "제목", "내용", "홍길동");
+
+        when(boardJpaRepository.findById(request.boardId())).thenReturn(Optional.empty());
+
+        // when & then
+        assertThrows(EntityNotFoundException.class, () -> postService.createPost(999L, request));
+    }
+
+    @Test
+    void 게시글_목록_조회_테스트() {
+        // given
+        when(postJpaRepository.findByBoardId(1L)).thenReturn(List.of(post));
+
+        // when
+        List<PostResponse> responses = postService.getPostsByBoardId(1L);
+
+        // then
+        assertThat(responses).hasSize(1);
+        assertThat(responses.get(0).title()).isEqualTo(post.getTitle());
+        assertThat(responses.get(0).content()).isEqualTo(post.getContent());
+    }
+
+    @Test
+    void 게시글_단일_조회_테스트() {
+        // given
+        Long postId = 1L;
+        when(postJpaRepository.findById(postId)).thenReturn(Optional.of(post));
+
+        // when
+        PostResponse response = postService.getPostById(postId);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.id()).isEqualTo(post.getId());
+        assertThat(response.title()).isEqualTo(post.getTitle());
+        assertThat(response.content()).isEqualTo(post.getContent());
+    }
+
+    @Test
+    void 존재하지_않는_게시글_조회_테스트() {
+        // given
+        Long postId = 999L;
+        when(postJpaRepository.findById(postId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThrows(EntityNotFoundException.class, () -> postService.getPostById(postId));
+    }
+
+    @Test
+    void 게시글_수정_테스트() {
+        // given
+        PostRequest request = new PostRequest(1L, "수정된 제목", "수정된 내용", "홍길동");
+
+        when(postJpaRepository.findById(1L)).thenReturn(Optional.of(post));
+
+        // when
+        PostResponse response = postService.updatePost(1L, request);
+
+        // then
+        assertThat(response.title()).isEqualTo(request.title());
+        assertThat(response.content()).isEqualTo(request.content());
+    }
+
+    @Test
+    void 존재하지_않는_게시글_수정_테스트() {
+        // given
+        PostRequest request = new PostRequest(1L, "수정된 제목", "수정된 내용", "홍길동");
+
+        when(postJpaRepository.findById(999L)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThrows(EntityNotFoundException.class, () -> postService.updatePost(999L, request));
+    }
+
+    @Test
+    void 게시글_삭제_테스트() {
+        // given
+        when(postJpaRepository.existsById(1L)).thenReturn(true);
+        doNothing().when(postJpaRepository).deleteById(1L);
+
+        // when
+        postService.deletePost(1L);
+
+        // then
+        verify(postJpaRepository, times(1)).deleteById(1L);
+    }
+
+    @Test
+    void 존재하지_않는_게시글_삭제_테스트() {
+        // given
+        when(postJpaRepository.existsById(999L)).thenReturn(false);
+
+        // when & then
+        assertThrows(EntityNotFoundException.class, () -> postService.deletePost(999L));
+    }
+
+}

--- a/src/test/java/com/hongjunland/boardtemplate/post/presentation/PostControllerTest.java
+++ b/src/test/java/com/hongjunland/boardtemplate/post/presentation/PostControllerTest.java
@@ -1,0 +1,230 @@
+package com.hongjunland.boardtemplate.post.presentation;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hongjunland.boardtemplate.post.application.PostService;
+import com.hongjunland.boardtemplate.post.dto.PostRequest;
+import com.hongjunland.boardtemplate.post.dto.PostResponse;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(PostController.class)
+@ExtendWith(SpringExtension.class)
+public class PostControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private PostService postService;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+
+    @Test
+    void 게시글_생성_API_테스트() throws Exception {
+        // given
+        Long boardId = 1L;
+        PostRequest request = PostRequest.builder()
+                .title("새로운 게시글")
+                .content("내용입니다.")
+                .author("홍길동")
+                .build();
+
+        PostResponse response = PostResponse.builder()
+                .id(1L)
+                .boardId(boardId)
+                .boardName("공지사항")
+                .title(request.title())
+                .content(request.content())
+                .author(request.author())
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+
+        when(postService.createPost(eq(boardId), any(PostRequest.class))).thenReturn(response);
+
+        // when & then
+        mockMvc.perform(post("/api/v1/boards/{boardId}/posts", boardId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.id").value(response.id()))
+                .andExpect(jsonPath("$.data.title").value(response.title()));
+    }
+
+    @Test
+    void 게시글_목록_조회_API_테스트() throws Exception {
+        // given
+        Long boardId = 1L;
+        List<PostResponse> responses = List.of(
+                PostResponse.builder()
+                        .id(1L).boardId(boardId).boardName("공지사항")
+                        .title("첫 번째 게시글").content("내용입니다.").author("홍길동")
+                        .createdAt(LocalDateTime.now()).updatedAt(LocalDateTime.now())
+                        .build(),
+                PostResponse.builder()
+                        .id(2L).boardId(boardId).boardName("공지사항")
+                        .title("두 번째 게시글").content("또 다른 내용").author("이순신")
+                        .createdAt(LocalDateTime.now()).updatedAt(LocalDateTime.now())
+                        .build()
+        );
+
+        when(postService.getPostsByBoardId(boardId)).thenReturn(responses);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/boards/{boardId}/posts", boardId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.size()").value(responses.size()))
+                .andExpect(jsonPath("$.data[0].title").value(responses.get(0).title()))
+                .andExpect(jsonPath("$.data[1].title").value(responses.get(1).title()));
+    }
+
+    @Test
+    void 존재하지_않는_게시글_목록_조회_API_테스트() throws Exception {
+        // given
+        Long boardId = 1L;
+
+        when(postService.getPostsByBoardId(boardId)).thenThrow(new EntityNotFoundException("존재하지 않는 게시판"));
+        // when & then
+        mockMvc.perform(get("/api/v1/boards/{boardId}/posts", boardId))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("존재하지 않는 게시판"));
+    }
+
+    @Test
+    void 게시글_단일_조회_API_테스트() throws Exception {
+        // given
+        Long boardId = 1L;
+        Long postId = 1L;
+        PostResponse response = PostResponse.builder()
+                .id(postId)
+                .boardId(boardId)
+                .boardName("공지사항")
+                .title("첫 번째 게시글")
+                .content("내용입니다.")
+                .author("홍길동")
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+
+        when(postService.getPostById(postId)).thenReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/boards/{boardId}/posts/{postId}", boardId, postId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.id").value(response.id()))
+                .andExpect(jsonPath("$.data.title").value(response.title()));
+    }
+
+    @Test
+    void 존재하지_않는_게시글_조회_API_테스트() throws Exception {
+        // given
+        Long boardId = 111L;
+        Long postId = 999L;
+        when(postService.getPostById(postId)).thenThrow(new EntityNotFoundException("게시글을 찾을 수 없습니다."));
+
+        // when & then
+        mockMvc.perform(get("/api/v1/boards/{boardId}/posts/{postId}", boardId, postId))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("게시글을 찾을 수 없습니다."));
+    }
+
+    @Test
+    void 게시글_수정_API_테스트() throws Exception {
+        // given
+        Long boardId = 1L;
+        Long postId = 1L;
+        PostRequest request = PostRequest.builder()
+                .title("수정된 제목")
+                .content("수정된 내용")
+                .build();
+
+        PostResponse response = PostResponse.builder()
+                .id(postId)
+                .boardId(boardId)
+                .boardName("공지사항")
+                .title(request.title())
+                .content(request.content())
+                .author("홍길동")
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+
+        when(postService.updatePost(eq(postId), any(PostRequest.class))).thenReturn(response);
+
+        // when & then
+        mockMvc.perform(put("/api/v1/boards/{boardId}/posts/{postId}", boardId, postId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.title").value(request.title()));
+    }
+
+    @Test
+    void 존재하지_않는_게시글_수정_API_테스트() throws Exception {
+        // given
+        Long boardId = 111L;
+        Long postId = 999L;
+        PostRequest request = PostRequest.builder()
+                .title("수정된 제목")
+                .content("수정된 내용")
+                .build();
+        when(postService.updatePost(postId, request)).thenThrow(new EntityNotFoundException("게시글을 찾을 수 없습니다."));
+
+        // when & then
+        mockMvc.perform(put("/api/v1/boards/{boardId}/posts/{postId}", boardId, postId, request)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                )
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("게시글을 찾을 수 없습니다."));
+    }
+
+    @Test
+    void 게시글_삭제_API_테스트() throws Exception {
+        // given
+        Long boardId = 1L;
+        Long postId = 1L;
+        doNothing().when(postService).deletePost(postId);
+
+        // when & then
+        mockMvc.perform(delete("/api/v1/boards/{boardId}/posts/{postId}", boardId, postId))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void 존재하지_않는_게시글_삭제_API_테스트() throws Exception {
+        // given
+        Long boardId = 111L;
+        Long postId = 999L;
+        doThrow(new EntityNotFoundException("게시글을 찾을 수 없습니다."))
+                .when(postService).deletePost(postId);
+
+        // when & then
+        mockMvc.perform(delete("/api/v1/boards/{boardId}/posts/{postId}", boardId, postId))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("게시글을 찾을 수 없습니다."));
+    }
+}


### PR DESCRIPTION
게시글(Post) 기능을 추가하고, 기본적인 CRUD 기능을 구현했습니다.
게시판(Board) - 게시글(Post) 관계를 반영하여 RESTful API 구조를 설계하였으며,
테스트 코드 및 Hibernate N+1 문제 해결을 포함하였습니다.